### PR TITLE
chore: update CA-PowerToys replace commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Writing policies to file policies.json...
 ### Exporting all Policies and associated Groups, replace keys with values in the policies file and cleanup for import
     
 ```console
-> ca-pwt --access_token $token export-policies --output_file policies.json cleanup-policies replace-keys-by-values export-groups --output_file groups.json cleanup-groups
+> ca-pwt --access_token $token export-policies --output_file policies.json cleanup-policies replace-guids-with-attrs export-groups --output_file groups.json cleanup-groups
 ```
 ```
 Exporting ca policies...

--- a/src/ca_pwt/__init__.py
+++ b/src/ca_pwt/__init__.py
@@ -17,7 +17,7 @@ from ca_pwt.groups import (
     cleanup_groups,
 )
 
-from ca_pwt.policies_mappings import replace_values_by_keys_in_policies, replace_keys_by_values_in_policies
+from ca_pwt.policies_mappings import replace_attrs_with_guids_in_policies, replace_guids_with_attrs_in_policies
 
 from ca_pwt.policies import (
     load_policies,

--- a/src/ca_pwt/app.py
+++ b/src/ca_pwt/app.py
@@ -2,9 +2,9 @@ import click
 from ca_pwt.commands import (
     export_policies_cmd,
     import_policies_cmd,
-    replace_values_by_keys_cmd,
+    replace_attrs_with_guids_cmd,
     cleanup_policies_cmd,
-    replace_keys_by_values_cmd,
+    replace_guids_with_attrs_cmd,
     acquire_token_cmd,
     export_groups_cmd,
     import_groups_cmd,
@@ -16,7 +16,10 @@ from ca_pwt.commands import (
 @click.group(
     name="CA-PowerToys",
     chain=True,
-    help="A set of tools to help manage Conditional Access policies in Entra ID",
+    help="A set of tools designed to streamline the management of Conditional Access policies in Entra ID. "
+    "These tools specialize in importing and exporting CA policies and groups, optimizing files for human and machine "
+    "readability as needed. Additionally, they facilitate the removal of extraneous attributes for smoother "
+    "editing workflows, and facilitate a devops-like workflow for managing CA policies.",
 )
 @click.option(
     "--log_level",
@@ -40,9 +43,9 @@ def cli(ctx: click.Context, access_token: str, log_level: str):
 cli.add_command(acquire_token_cmd)
 cli.add_command(import_policies_cmd)
 cli.add_command(export_policies_cmd)
-cli.add_command(replace_values_by_keys_cmd)
+cli.add_command(replace_attrs_with_guids_cmd)
 cli.add_command(cleanup_policies_cmd)
-cli.add_command(replace_keys_by_values_cmd)
+cli.add_command(replace_guids_with_attrs_cmd)
 cli.add_command(export_groups_cmd)
 cli.add_command(import_groups_cmd)
 cli.add_command(cleanup_groups_cmd)

--- a/src/ca_pwt/commands.py
+++ b/src/ca_pwt/commands.py
@@ -19,7 +19,7 @@ from ca_pwt.groups import (
 )
 from ca_pwt.helpers.graph_api import DuplicateActionEnum
 
-from ca_pwt.policies_mappings import replace_keys_by_values_in_policies, replace_values_by_keys_in_policies
+from ca_pwt.policies_mappings import replace_guids_with_attrs_in_policies, replace_attrs_with_guids_in_policies
 
 _logger = logging.getLogger(__name__)
 
@@ -183,26 +183,28 @@ def acquire_token_cmd(
 
 
 @click.command(
-    "replace-keys-by-values",
-    help="Replaces keys by values in CA policies"
-    " (e.g. group ids by group names, user ids by user principal names, etc.)",
+    "replace-guids-with-attrs",
+    help="Makes the CA policies file human-readable, by replacing guids with "
+    " correspondent attributes "
+    "(e.g. group ids by group names, user ids by user principal names, etc.)",
 )
 @click.pass_context
 @_access_token_option
 @_output_file_option
 @_input_file_option
-def replace_keys_by_values_cmd(
+def replace_guids_with_attrs_cmd(
     ctx: click.Context,
     input_file: str,
     output_file: str,
     access_token: str | None = None,
 ):
-    """Replaces keys by values in CA policies"""
+    """Makes the CA policies file human-readable, by replacing guids with
+    correspondent attributes (e.g. group ids by group names, user ids by user principal names, etc.)"""
 
     try:
         ctx.ensure_object(dict)
         click.secho(
-            "Replacing keys by values in CA policies...",
+            "Replacing guids with attributes in CA policies...",
             fg="yellow",
         )
         access_token = _get_from_ctx_if_none(ctx, "access_token", access_token, acquire_token_cmd)
@@ -211,7 +213,7 @@ def replace_keys_by_values_cmd(
         click.echo(f"Input file: {input_file}; Output file: {output_file}")
 
         policies = load_policies(input_file)
-        policies = replace_keys_by_values_in_policies(access_token, policies)
+        policies = replace_guids_with_attrs_in_policies(access_token, policies)
 
         save_policies(policies=policies, output_file=output_file)
 
@@ -222,26 +224,28 @@ def replace_keys_by_values_cmd(
 
 
 @click.command(
-    "replace-values-by-keys",
-    help="Replaces values by keys in CA policies"
-    " (e.g. group names by group ids, user principal names by user ids, etc.)",
+    "replace-attrs-with-guids",
+    help="Makes the CA policies file machine-readable, by replacing attributes with "
+    " correspondent guids "
+    "(e.g. group names by group ids, user principal names by user ids, etc.)",
 )
 @click.pass_context
 @_access_token_option
 @_output_file_option
 @_input_file_option
-def replace_values_by_keys_cmd(
+def replace_attrs_with_guids_cmd(
     ctx: click.Context,
     input_file: str,
     output_file: str,
     access_token: str | None = None,
 ):
-    """Replaces values by keys in CA policies"""
+    """Makes the CA policies file machine-readable, by replacing attributes with
+    correspondent guids (e.g. group names by group ids, user principal names by user ids, etc.)"""
 
     try:
         ctx.ensure_object(dict)
         click.secho(
-            "Replacing values by keys in CA policies...",
+            "Replacing attributes with guids in CA policies...",
             fg="yellow",
         )
 
@@ -252,7 +256,7 @@ def replace_values_by_keys_cmd(
         click.echo(f"Input file: {input_file}; Output file: {output_file}")
 
         policies = load_policies(input_file)
-        policies = replace_values_by_keys_in_policies(access_token, policies)
+        policies = replace_attrs_with_guids_in_policies(access_token, policies)
 
         save_policies(policies=policies, output_file=output_file)
 
@@ -302,7 +306,8 @@ def export_policies_cmd(
 
 @click.command(
     "cleanup-policies",
-    help="Cleans up CA policies file for import (e.g. removes createdDateTime, modifiedDateTime, id, templateId",
+    help="Removes read-only and unnecessary odata attributes from the provided policies JSON file, "
+    "preparing it for successful import.",
 )
 @click.pass_context
 @_output_file_option
@@ -328,7 +333,11 @@ def cleanup_policies_cmd(ctx: click.Context, input_file: str, output_file: str):
         _exit_with_exception(e)
 
 
-@click.command("cleanup-groups", help="Cleans up groups file for import")
+@click.command(
+    "cleanup-groups",
+    help="Removes read-only and unnecessary odata attributes from the provided groups "
+    "JSON file, preparing it for successful import.",
+)
 @click.pass_context
 @_output_file_option
 @_input_file_option

--- a/src/ca_pwt/policies.py
+++ b/src/ca_pwt/policies.py
@@ -1,7 +1,7 @@
 import logging
 from ca_pwt.helpers.utils import remove_element_from_dict, cleanup_odata_dict, ensure_list
 from ca_pwt.helpers.graph_api import EntityAPI, DuplicateActionEnum
-from ca_pwt.policies_mappings import replace_values_by_keys_in_policies
+from ca_pwt.policies_mappings import replace_attrs_with_guids_in_policies
 from ca_pwt.groups import get_groups_by_ids
 from typing import Any
 
@@ -81,7 +81,7 @@ def import_policies(
     are not allowed when importing."""
 
     policies_api = PoliciesAPI(access_token=access_token)
-    policies = replace_values_by_keys_in_policies(access_token, policies)
+    policies = replace_attrs_with_guids_in_policies(access_token, policies)
     # make sure the policies are cleaned up
     policies = cleanup_policies(policies)
     created_policies: list[tuple[str, str]] = []
@@ -106,7 +106,7 @@ def get_groups_in_policies(
     If ignore_not_found is True, groups that are not found are ignored.
     Returns a dictionary with the groups."""
     # make sure that all groups are in the key format
-    policies = replace_values_by_keys_in_policies(
+    policies = replace_attrs_with_guids_in_policies(
         access_token,
         policies,
         lookup_groups=True,

--- a/src/ca_pwt/policies_mappings.py
+++ b/src/ca_pwt/policies_mappings.py
@@ -174,7 +174,7 @@ def _replace_with_key_value_lookup(
     return lookup_cache
 
 
-def replace_values_by_keys_in_policies(
+def replace_attrs_with_guids_in_policies(
     access_token: str,
     policies: list[dict],
     *,
@@ -249,7 +249,7 @@ def replace_values_by_keys_in_policies(
     return policies
 
 
-def replace_keys_by_values_in_policies(
+def replace_guids_with_attrs_in_policies(
     access_token: str,
     policies: list[dict],
     *,

--- a/tests/import_entity_cmd_test_utils.py
+++ b/tests/import_entity_cmd_test_utils.py
@@ -117,7 +117,9 @@ def _test_import_entity_overwrite(access_token: str, cli: BaseCommand, entity_ap
             assert result.exit_code == 0
 
         # check if the policies were imported
-        _assert_entity_existence(entity_api, test_entity["displayName"], 1, "Test entity was not imported or overwritten.")
+        _assert_entity_existence(
+            entity_api, test_entity["displayName"], 1, "Test entity was not imported or overwritten."
+        )
 
 
 def _test_import_entity_fail(access_token: str, cli: BaseCommand, entity_api: EntityAPI, test_entity: dict):

--- a/tests/replace_cmds_test.py
+++ b/tests/replace_cmds_test.py
@@ -2,8 +2,8 @@ import json
 import time
 import pytest
 from src.ca_pwt.commands import (
-    replace_keys_by_values_cmd,
-    replace_values_by_keys_cmd,
+    replace_guids_with_attrs_cmd,
+    replace_attrs_with_guids_cmd,
 )
 from click.testing import CliRunner
 from .utils import assert_valid_output_file, SLEEP_BETWEEN_TESTS, VALID_POLICIES
@@ -16,7 +16,7 @@ def run_around_tests():
     time.sleep(SLEEP_BETWEEN_TESTS)
 
 
-def test_replace_keys_by_values_replace_values_by_keys(access_token: str):
+def test_replace_guids_with_attrs_and_replace_attrs_with_guids(access_token: str):
     """Tests if the replace command works as expected"""
     runner = CliRunner()
     with runner.isolated_filesystem():
@@ -33,7 +33,7 @@ def test_replace_keys_by_values_replace_values_by_keys(access_token: str):
         assert_valid_output_file(test_data_file)
 
         result = runner.invoke(
-            replace_keys_by_values_cmd,
+            replace_guids_with_attrs_cmd,
             [
                 "--access_token",
                 access_token,
@@ -87,7 +87,7 @@ def test_replace_keys_by_values_replace_values_by_keys(access_token: str):
             f.write(json.dumps(data, indent=4))
 
         result = runner.invoke(
-            replace_values_by_keys_cmd,
+            replace_attrs_with_guids_cmd,
             [
                 "--access_token",
                 access_token,


### PR DESCRIPTION
- Updated the command names and help messages for clarity and consistency.
- Renamed `replace_keys_by_values_cmd` to `replace_guids_with_attrs_cmd` to reflect the functionality of replacing guids with correspondent attributes in CA policies.
- Renamed `replace_values_by_keys_cmd` to `replace_attrs_with_guids_cmd` to reflect the functionality of replacing attributes with correspondent guids in CA policies.
- Updated the help messages for both commands to provide a clear explanation of their purpose.
- Updated the import and export commands to use the new command names.
- Updated the test cases to reflect the changes in command names and help messages.